### PR TITLE
Allow update policies to hide changes on succeeded checks

### DIFF
--- a/cli/pcluster/config/config_patch.py
+++ b/cli/pcluster/config/config_patch.py
@@ -225,17 +225,12 @@ class ConfigPatch(object):
         patch_allowed = True
 
         for change in self.changes:
-            if change.update_policy != UpdatePolicy.IGNORED:
+            check_result, reason, action_needed, print_change = change.update_policy.check(change, self)
+            if print_change:
                 section_name = get_file_section_name(change.section_key, change.section_label)
-
-                check_result, reason, action_needed = change.update_policy.check(change, self)
 
                 if check_result != UpdatePolicy.CheckResult.SUCCEEDED:
                     patch_allowed = False
-                if change.update_policy == UpdatePolicy.READ_ONLY_RESOURCE_BUCKET and patch_allowed:
-                    # Special case for cluster_resource_bucket/ResourcesS3Bucket
-                    # Do not append diff if patch is allowed
-                    continue
                 rows.append(
                     [
                         section_name,


### PR DESCRIPTION
This commit introduces the logic to allow Update Policies to determine if a specific allowed change should be displayed in the changes report or not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
